### PR TITLE
feat: Discord integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +182,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +215,15 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "brotli"
@@ -228,6 +257,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -371,6 +406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +432,16 @@ dependencies = [
  "chrono",
  "nom",
  "once_cell",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -426,6 +480,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+ "serde",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +528,16 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -593,6 +677,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serenity",
  "teloxide",
  "tokio",
  "tracing",
@@ -735,6 +820,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -928,13 +1023,13 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls",
+ "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1629,7 +1724,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.36",
  "socket2",
  "thiserror 2.0.18",
  "tokio",
@@ -1649,7 +1744,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1849,7 +1944,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -1857,7 +1952,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -1867,7 +1962,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1947,6 +2042,20 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
@@ -1954,7 +2063,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -1979,6 +2088,17 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2057,6 +2177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2174,6 +2313,48 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "serenity"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bde37f42765dfdc34e2a039e0c84afbf79a3101c1941763b0beb816c2f17541"
+dependencies = [
+ "arrayvec",
+ "async-trait",
+ "base64",
+ "bitflags",
+ "bytes",
+ "dashmap",
+ "flate2",
+ "futures",
+ "mime_guess",
+ "parking_lot",
+ "percent-encoding",
+ "reqwest",
+ "rustc-hash",
+ "secrecy",
+ "serde",
+ "serde_cow",
+ "serde_json",
+ "time",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "typemap_rev",
+ "url",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2588,11 +2769,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -2605,6 +2797,22 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2676,6 +2884,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2748,6 +2957,39 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "typemap_rev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicase"
@@ -2953,6 +3195,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 teloxide = { version = "0.17", default-features = false, features = ["macros", "rustls", "rustls-native-roots", "ctrlc_handler"] }
+serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model", "cache", "rustls_backend"] }
 url = "2"
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Create `~/.femtobot/config.json`:
         "context_bias": "",
         "timestamp_granularities": ["segment"]
       }
+    },
+    "discord": {
+      "token": "YOUR_DISCORD_BOT_TOKEN",
+      "allow_from": ["123456789012345678"],
+      "allowed_channels": ["123456789012345678"]
     }
   }
 }
@@ -123,6 +128,7 @@ femtobot uses an actor-like model with a central `MessageBus`:
 
 - `Agent`: context handling and LLM orchestration.
 - `Telegram`: chat input/output transport.
+- `Discord`: chat input/output transport.
 - `Tools`: executable capability modules.
 - `Memory`: extraction, retrieval, and consolidation loop.
 

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct InboundMessage {
@@ -21,28 +21,31 @@ pub struct MessageBus {
     inbound_tx: mpsc::Sender<InboundMessage>,
     outbound_tx: mpsc::Sender<OutboundMessage>,
     inbound_rx: Arc<Mutex<mpsc::Receiver<InboundMessage>>>,
-}
-
-pub struct BusHandle {
-    pub outbound_rx: Arc<Mutex<mpsc::Receiver<OutboundMessage>>>,
+    outbound_broadcast_tx: broadcast::Sender<OutboundMessage>,
 }
 
 impl MessageBus {
-    pub fn new() -> (Self, BusHandle) {
+    pub fn new() -> Self {
         let (inbound_tx, inbound_rx) = mpsc::channel(100);
-        let (outbound_tx, outbound_rx) = mpsc::channel(100);
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(100);
+        let (outbound_broadcast_tx, _) = broadcast::channel(100);
 
         let inbound_rx = Arc::new(Mutex::new(inbound_rx));
-        let outbound_rx = Arc::new(Mutex::new(outbound_rx));
 
         let bus = MessageBus {
             inbound_tx,
             outbound_tx,
             inbound_rx: inbound_rx.clone(),
+            outbound_broadcast_tx: outbound_broadcast_tx.clone(),
         };
 
-        let handle = BusHandle { outbound_rx };
-        (bus, handle)
+        tokio::spawn(async move {
+            while let Some(msg) = outbound_rx.recv().await {
+                let _ = outbound_broadcast_tx.send(msg);
+            }
+        });
+
+        bus
     }
 
     pub async fn publish_inbound(&self, msg: InboundMessage) {
@@ -56,5 +59,9 @@ impl MessageBus {
     pub async fn consume_inbound(&self) -> Option<InboundMessage> {
         let mut rx = self.inbound_rx.lock().await;
         rx.recv().await
+    }
+
+    pub fn subscribe_outbound(&self) -> broadcast::Receiver<OutboundMessage> {
+        self.outbound_broadcast_tx.subscribe()
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,0 +1,193 @@
+use crate::bus::{InboundMessage, MessageBus, OutboundMessage};
+use crate::config::AppConfig;
+use anyhow::{anyhow, Result};
+use serenity::async_trait;
+use serenity::http::Http;
+use serenity::model::channel::Message as DiscordMessage;
+use serenity::model::gateway::Ready;
+use serenity::model::id::ChannelId;
+use serenity::prelude::*;
+use std::collections::HashSet;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+const DISCORD_MESSAGE_LIMIT: usize = 2000;
+
+pub async fn start(cfg: AppConfig, bus: MessageBus) -> Result<()> {
+    let token = cfg.discord_bot_token.trim().to_string();
+    if token.is_empty() {
+        return Err(anyhow!("discord token is missing"));
+    }
+
+    let intents = GatewayIntents::GUILD_MESSAGES
+        | GatewayIntents::DIRECT_MESSAGES
+        | GatewayIntents::MESSAGE_CONTENT;
+
+    let handler = DiscordHandler::new(&cfg, bus.clone());
+    let mut client = Client::builder(token, intents)
+        .event_handler(handler)
+        .await
+        .map_err(|err| anyhow!("discord client initialization failed: {err}"))?;
+
+    spawn_outbound_forwarder(client.http.clone(), bus.subscribe_outbound());
+
+    client
+        .start()
+        .await
+        .map_err(|err| anyhow!("discord runtime error: {err}"))?;
+    Ok(())
+}
+
+struct DiscordHandler {
+    bus: MessageBus,
+    allowed_channels: HashSet<u64>,
+    allow_from: Vec<String>,
+}
+
+impl DiscordHandler {
+    fn new(cfg: &AppConfig, bus: MessageBus) -> Self {
+        let allowed_channels = cfg
+            .discord_allowed_channels
+            .iter()
+            .filter_map(|raw| raw.trim().parse::<u64>().ok())
+            .collect::<HashSet<_>>();
+        let allow_from = cfg
+            .discord_allow_from
+            .iter()
+            .map(|entry| entry.trim().to_ascii_lowercase())
+            .filter(|entry| !entry.is_empty())
+            .collect::<Vec<_>>();
+        Self {
+            bus,
+            allowed_channels,
+            allow_from,
+        }
+    }
+
+    fn is_channel_allowed(&self, msg: &DiscordMessage) -> bool {
+        if self.allowed_channels.is_empty() || msg.guild_id.is_none() {
+            return true;
+        }
+        self.allowed_channels.contains(&msg.channel_id.get())
+    }
+
+    fn is_sender_allowed(&self, msg: &DiscordMessage) -> bool {
+        if self.allow_from.is_empty() {
+            return true;
+        }
+        let uid = msg.author.id.get().to_string();
+        let uname = msg.author.name.to_ascii_lowercase();
+        let mention = format!("<@{}>", msg.author.id.get());
+        self.allow_from.iter().any(|allowed| {
+            allowed == &uid
+                || allowed == &uname
+                || allowed == &format!("@{uname}")
+                || allowed == &mention
+        })
+    }
+}
+
+#[async_trait]
+impl EventHandler for DiscordHandler {
+    async fn message(&self, ctx: Context, msg: DiscordMessage) {
+        if msg.author.bot {
+            return;
+        }
+        if !self.is_channel_allowed(&msg) || !self.is_sender_allowed(&msg) {
+            return;
+        }
+
+        let text = msg.content.trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+
+        if msg.guild_id.is_some() {
+            let bot_id = ctx.cache.current_user().id;
+            let mentioned = msg.mentions.iter().any(|user| user.id == bot_id);
+            if !mentioned {
+                return;
+            }
+        }
+
+        let _typing = msg.channel_id.start_typing(&ctx.http);
+
+        self.bus
+            .publish_inbound(InboundMessage {
+                channel: "discord".to_string(),
+                chat_id: msg.channel_id.get().to_string(),
+                sender_id: msg.author.id.get().to_string(),
+                content: text,
+            })
+            .await;
+    }
+
+    async fn ready(&self, _ctx: Context, ready: Ready) {
+        info!("discord connected as {}", ready.user.name);
+    }
+}
+
+fn spawn_outbound_forwarder(
+    http: Arc<Http>,
+    mut rx: tokio::sync::broadcast::Receiver<OutboundMessage>,
+) {
+    tokio::spawn(async move {
+        loop {
+            let msg = match rx.recv().await {
+                Ok(msg) => msg,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    info!("outbound channel closed, discord forwarder shutting down");
+                    break;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!("discord outbound lagged, skipped {skipped} message(s)");
+                    continue;
+                }
+            };
+
+            if msg.channel != "discord" {
+                continue;
+            }
+
+            let Ok(raw_channel_id) = msg.chat_id.parse::<u64>() else {
+                warn!("invalid discord chat_id: {}", msg.chat_id);
+                continue;
+            };
+
+            if let Err(err) =
+                send_discord_message(&http, ChannelId::new(raw_channel_id), &msg.content).await
+            {
+                warn!("discord send failed for channel {}: {err}", msg.chat_id);
+            }
+        }
+    });
+}
+
+async fn send_discord_message(
+    http: &Http,
+    channel_id: ChannelId,
+    text: &str,
+) -> serenity::Result<()> {
+    if text.len() <= DISCORD_MESSAGE_LIMIT {
+        channel_id.say(http, text).await?;
+        return Ok(());
+    }
+
+    let mut remaining = text;
+    while !remaining.is_empty() {
+        let chunk_len = if remaining.len() <= DISCORD_MESSAGE_LIMIT {
+            remaining.len()
+        } else {
+            remaining[..DISCORD_MESSAGE_LIMIT]
+                .rfind('\n')
+                .unwrap_or(DISCORD_MESSAGE_LIMIT)
+        };
+        let chunk = &remaining[..chunk_len];
+        channel_id.say(http, chunk).await?;
+        remaining = &remaining[chunk_len..];
+        if remaining.starts_with('\n') {
+            remaining = &remaining[1..];
+        }
+    }
+    Ok(())
+}

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -48,7 +48,9 @@ where
             .parse::<u8>()
             .map(Some)
             .map_err(|_| D::Error::custom("count string must be an integer between 0 and 255")),
-        Some(_) => Err(D::Error::custom("count must be an integer or integer string")),
+        Some(_) => Err(D::Error::custom(
+            "count must be an integer or integer string",
+        )),
     }
 }
 


### PR DESCRIPTION

<img width="1223" height="630" alt="discord-demo-femtobot" src="https://github.com/user-attachments/assets/2747156d-bfe4-4a29-b8b5-c85561b73b1f" />

- Added new Discord transport module:
      - src/discord.rs
      - Inbound handling:
          - ignores bot messages
          - supports optional sender allowlist (channels.discord.allow_from)
          - supports optional guild channel allowlist (channels.discord.allowed_channels)
          - requires mention in guild channels (DMs are accepted directly)
      - Outbound handling:
          - forwards bus messages for channel == "discord"
          - chunks messages to Discord’s 2000 character limit
  - Updated bus outbound architecture for multi-channel fanout:
      - src/bus.rs
      - switched from single-consumer outbound queue semantics to per-channel subscriptions via broadcast
      - prevents message loss/race when multiple channel forwarders are active
  - Updated startup wiring:
      - src/main.rs
      - starts Telegram and Discord independently when configured
      - preserves shared agent + cron runtime
  - Updated Telegram forwarder to use outbound subscription:
      - src/telegram.rs
  - Extended config schema and loading:
      - src/config.rs
      - new fields:
          - channels.discord.token
          - channels.discord.allow_from
          - channels.discord.allowed_channels
      - env support:
          - DISCORD_BOT_TOKEN
          - FEMTOBOT_DISCORD_ALLOW_FROM
          - FEMTOBOT_DISCORD_ALLOWED_CHANNELS
  - Extended interactive configure flow:
      - src/configure.rs
      - added Discord configuration step
      - reordered menu so model configuration appears immediately after provider
  - Added dependency:
      - Cargo.toml (serenity)
  - Updated docs:
      - README.md (Discord config example + architecture note)

Fixes #2 