### PR TITLE
Don't throw error if systemd isn't present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -184,8 +184,8 @@ EOF
 setup_service() {
     if [[ "${OS_TYPE}" == "linux" ]]; then
         if ! command -v systemctl >/dev/null 2>&1; then
-            error "systemctl is required on Linux for background daemon mode"
-            exit 1
+			info "systemctl is required on Linux for background daemon mode"
+			return 0
         fi
 
         local service_dir="$HOME/.config/systemd/user"


### PR DESCRIPTION
Couldn't create a Containerfile because the setup script would throw an error. We can just post an info and skip, Podman/docker containers don't have an init system.